### PR TITLE
Option -enable-cxx-interop is a frontend option.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             dependencies: ["CPPExample"],
             // Note: These flags are to allow importing CPPXLA, it must be importted as
             // @_implementationOnly or it will conflict with other headers.
-            swiftSettings: [.unsafeFlags(["-enable-cxx-interop"])]
+            swiftSettings: [.unsafeFlags(["-Xfrontend", "-enable-cxx-interop"])]
         ),
         .testTarget(
             name: "ExampleTests",


### PR DESCRIPTION
Otherwise I get the following error: <unknown>:0: error: unknown argument: '-enable-cxx-interop'%.
